### PR TITLE
Chore(devcontainer): Update image version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,8 +14,5 @@
   "extensions": [
     "ms-python.python",
     "ms-toolsai.jupyter"
-  ],
-  "features": {
-    "github-cli": "latest"
-  }
+  ]
 }

--- a/.docker/docker-compose.dev.yml
+++ b/.docker/docker-compose.dev.yml
@@ -2,6 +2,6 @@ version: "3.9"
 
 services:
   jupyter:
-    image: utkusarioglu/conda-math-devcontainer:1.0.0
+    image: utkusarioglu/conda-math-devcontainer:1.0.4
     volumes:
       - ..:/utkusarioglu-com/templates/conda-math-repo-template


### PR DESCRIPTION
- Switch to image version `1.0.4`. This update does the following:
  * Removes the need to install github cli
  * Replaces vim with nvim
